### PR TITLE
Add demo vault/ssh setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3'
+services:
+  vault:
+    image: vault:1.0.3
+    environment:
+      VAULT_DEV_ROOT_TOKEN_ID: vault-root-token
+    cap_add:
+      - IPC_LOCK
+    ports:
+     - "8200:8200"
+  sshd:
+    build:
+      context: ./ssh-server
+      dockerfile: Dockerfile
+    environment:
+      VAULT_TOKEN: vault-root-token
+      VAULT_ADDR: http://vault:8200
+    ports:
+     - "2222:22"

--- a/ssh-server/Dockerfile
+++ b/ssh-server/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:bionic
+
+RUN apt-get update && \
+    apt-get install -y openssh-server curl unzip netcat
+RUN mkdir /var/run/sshd
+
+RUN mkdir -p /tmp/vault && \
+    curl -sLo  /tmp/vault/vault.zip https://releases.hashicorp.com/vault/1.0.3/vault_1.0.3_linux_amd64.zip && \
+    unzip -d /usr/local/bin /tmp/vault/vault.zip && \
+    rm -rf /tmp/vault
+
+ADD sshd.sh /
+ADD sshd_config /etc/ssh/sshd_config
+
+# SSH login fix. Otherwise user is kicked off after login
+RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
+
+EXPOSE 22
+CMD ["/sshd.sh"]

--- a/ssh-server/ssh-from-host.sh
+++ b/ssh-server/ssh-from-host.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export VAULT_TOKEN=vault-root-token
+export VAULT_ADDR=http://localhost:8200
+
+keyfile=$HOME/.ssh/id_rsa.pub
+if [ -n "${1:-}" ]; then
+    keyfile="$1"
+fi
+
+tmpfile=$(mktemp /tmp/signed-ssh.XXXXXXXXXXXX)
+
+vault write -field=signed_key ssh-client-signer/sign/my-role public_key=@$keyfile > $tmpfile
+
+exec ssh -i $tmpfile -i $keyfile -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 root@localhost

--- a/ssh-server/sshd.sh
+++ b/ssh-server/sshd.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "--> Waiting for vault to start"
+timeout 30 sh -c 'until nc -z $0 $1; do sleep 1; done' vault 8200
+
+echo "--> Configuring vault SSH"
+vault secrets enable -path=ssh-client-signer ssh
+vault write ssh-client-signer/config/ca generate_signing_key=true
+vault write ssh-client-signer/roles/my-role -<<"EOH"
+{
+  "allow_user_certificates": true,
+  "allowed_users": "*",
+  "default_extensions": [
+    {
+      "permit-pty": ""
+    }
+  ],
+  "key_type": "ca",
+  "default_user": "root",
+  "ttl": "30m0s"
+}
+EOH
+
+vault read -field=public_key ssh-client-signer/config/ca > /etc/ssh/trusted-user-ca-keys.pem
+
+echo "--> Launching SSHD"
+/usr/sbin/sshd -D

--- a/ssh-server/sshd_config
+++ b/ssh-server/sshd_config
@@ -1,0 +1,124 @@
+#	$OpenBSD: sshd_config,v 1.101 2017/03/14 07:19:07 djm Exp $
+
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# This sshd was compiled with PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+# The strategy used for options in the default sshd_config shipped with
+# OpenSSH is to specify options with their default value where
+# possible, but leave them commented.  Uncommented options override the
+# default value.
+
+#Port 22
+#AddressFamily any
+#ListenAddress 0.0.0.0
+#ListenAddress ::
+
+#HostKey /etc/ssh/ssh_host_rsa_key
+#HostKey /etc/ssh/ssh_host_ecdsa_key
+#HostKey /etc/ssh/ssh_host_ed25519_key
+
+# Ciphers and keying
+#RekeyLimit default none
+
+# Logging
+#SyslogFacility AUTH
+LogLevel INFO
+
+# Authentication:
+
+#LoginGraceTime 2m
+PermitRootLogin yes
+#StrictModes yes
+#MaxAuthTries 6
+#MaxSessions 10
+
+#PubkeyAuthentication yes
+
+# Expect .ssh/authorized_keys2 to be disregarded by default in future.
+#AuthorizedKeysFile	.ssh/authorized_keys .ssh/authorized_keys2
+
+#AuthorizedPrincipalsFile none
+
+#AuthorizedKeysCommand none
+#AuthorizedKeysCommandUser nobody
+
+# For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
+#HostbasedAuthentication no
+# Change to yes if you don't trust ~/.ssh/known_hosts for
+# HostbasedAuthentication
+#IgnoreUserKnownHosts no
+# Don't read the user's ~/.rhosts and ~/.shosts files
+#IgnoreRhosts yes
+
+# To disable tunneled clear text passwords, change to no here!
+#PasswordAuthentication yes
+#PermitEmptyPasswords no
+
+# Change to yes to enable challenge-response passwords (beware issues with
+# some PAM modules and threads)
+ChallengeResponseAuthentication no
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+#KerberosGetAFSToken no
+
+# GSSAPI options
+#GSSAPIAuthentication no
+#GSSAPICleanupCredentials yes
+#GSSAPIStrictAcceptorCheck yes
+#GSSAPIKeyExchange no
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the ChallengeResponseAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via ChallengeResponseAuthentication may bypass
+# the setting of "PermitRootLogin without-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and ChallengeResponseAuthentication to 'no'.
+UsePAM yes
+
+#AllowAgentForwarding yes
+#AllowTcpForwarding yes
+#GatewayPorts no
+X11Forwarding yes
+#X11DisplayOffset 10
+#X11UseLocalhost yes
+#PermitTTY yes
+PrintMotd no
+#PrintLastLog yes
+#TCPKeepAlive yes
+#UseLogin no
+#PermitUserEnvironment no
+#Compression delayed
+#ClientAliveInterval 0
+#ClientAliveCountMax 3
+#UseDNS no
+#PidFile /var/run/sshd.pid
+#MaxStartups 10:30:100
+#PermitTunnel no
+#ChrootDirectory none
+#VersionAddendum none
+
+# no default banner path
+#Banner none
+
+# Allow client to pass locale environment variables
+AcceptEnv LANG LC_*
+
+# override default of no subsystems
+Subsystem	sftp	/usr/lib/openssh/sftp-server
+
+# Example of overriding settings on a per-user basis
+#Match User anoncvs
+#	X11Forwarding no
+#	AllowTcpForwarding no
+#	PermitTTY no
+#	ForceCommand cvs server
+
+TrustedUserCAKeys /etc/ssh/trusted-user-ca-keys.pem


### PR DESCRIPTION
This adds a docker-compose based vault & SSH server, that is configured for
vault's signed SSH certificates
(https://www.vaultproject.io/docs/secrets/ssh/signed-ssh-certificates.html .
This acts as a demo of how to set it up, and will also be a useful dev/test
target.